### PR TITLE
feat: initialize cillium-monitor chart

### DIFF
--- a/charts/cillium-monitor/CHANGELOG.md
+++ b/charts/cillium-monitor/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+This file documents all notable changes to the Helm Chart.
+The release numbering uses [semantic versioning](http://semver.org).
+
+## 0.0.1
+
+- Initialize chart

--- a/charts/cillium-monitor/Chart.yaml
+++ b/charts/cillium-monitor/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: cillium-monitor
+description: A Helm chart for deploying PodMonitor resources for Cillium's components
+type: application
+version: 0.0.1
+appVersion: "v1.12"
+keywords:
+  - cillium
+  - hubble
+maintainers:
+  - email: locmai0201@gmail.com
+    name: Loc Mai

--- a/charts/cillium-monitor/README.md
+++ b/charts/cillium-monitor/README.md
@@ -1,0 +1,17 @@
+# Excalidraw
+
+## Parameters
+
+### Common parameters
+
+| Name                        | Description                  | Value   |
+| --------------------------- | ---------------------------- | ------- |
+| `enablePodMonitor.agent`    | for cillium-agent metrics    | `true`  |
+| `enablePodMonitor.envoy`    | for cillium-envoy metrics    | `false` |
+| `enablePodMonitor.operator` | for cillium-operator metrics | `false` |
+| `enablePodMonitor.hubble`   | for hubble metrics           | `false` |
+
+
+## Additional notes
+
+TBD

--- a/charts/cillium-monitor/templates/agent-podmonitor.yaml
+++ b/charts/cillium-monitor/templates/agent-podmonitor.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: cillium-agent-metrics
+  labels:
+    k8s-app: cilium
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium
+  podMetricsEndpoints:
+  {{- if .Values.enablePodMonitor.agent -}}
+  - port: prometheus
+  {{- end }}
+  {{- if .Values.enablePodMonitor.envoy -}}
+  - port: envoy-metrics
+  {{- end }}
+  {{- if .Values.enablePodMonitor.hubble -}}
+  - port: hubble-metrics
+  {{- end }}

--- a/charts/cillium-monitor/templates/operator-podmonitor.yaml
+++ b/charts/cillium-monitor/templates/operator-podmonitor.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.enablePodMonitor.agent -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: cillium-agent-metrics
+  labels:
+    name: cilium-operator
+spec:
+  selector:
+    matchLabels:
+      name: cilium-operator
+  podMetricsEndpoints:
+  - port: prometheus
+{{- end }}

--- a/charts/cillium-monitor/values.yaml
+++ b/charts/cillium-monitor/values.yaml
@@ -1,0 +1,15 @@
+## @section Common parameters
+
+## Excalidraw image
+## ref: https://hub.docker.com/r/excalidraw/excalidraw/tags
+## @param enablePodMonitor.agent for cillium-agent metrics
+## @param enablePodMonitor.envoy for cillium-envoy metrics
+## @param enablePodMonitor.operator for cillium-operator metrics
+## @param enablePodMonitor.hubble for hubble metrics
+## 
+enablePodMonitor:
+  agent: true
+  envoy: false
+  operator: false
+
+  hubble: false


### PR DESCRIPTION
### What this PR does / why we need it

### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- add a Helm chart that only deploys PodMonitors as standalone resources for monitoring with Cillium.

### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart Version bumped
- [x] README.md was updated with readme-generator
- [x] CHANGELOG.md was updated